### PR TITLE
BTL 55 Gacha Pos Updates

### DIFF
--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_CowbellCollar.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_CowbellCollar.prefab
@@ -154,6 +154,7 @@ MonoBehaviour:
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
   GachaScale: {x: 120, y: 120, z: 120}
+  GachaLocation: {x: -0.1, y: 0.2, z: 0}
   mesh: {fileID: 1496038833456251771}
 --- !u!1 &7555318381588310970
 GameObject:

--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_CowboyHat.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_CowboyHat.prefab
@@ -185,4 +185,5 @@ MonoBehaviour:
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
   GachaScale: {x: 120, y: 120, z: 120}
+  GachaLocation: {x: 0, y: -0.3, z: 0}
   mesh: {fileID: 4965892131138533885}

--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Flower.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Flower.prefab
@@ -48,6 +48,7 @@ MonoBehaviour:
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
   GachaScale: {x: 100, y: 100, z: 100}
+  GachaLocation: {x: 0, y: -0.2, z: 0}
   mesh: {fileID: 5953644276766384086}
 --- !u!1 &5471886398792102930
 GameObject:

--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_GooglyEye.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_GooglyEye.prefab
@@ -352,5 +352,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
-  GachaScale: {x: 120, y: 120, z: 120}
+  GachaScale: {x: 140, y: 140, z: 140}
+  GachaLocation: {x: 0, y: 0, z: 0}
   mesh: {fileID: 3458976312587066806}

--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Moustache.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Moustache.prefab
@@ -153,4 +153,5 @@ MonoBehaviour:
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
   GachaScale: {x: 120, y: 120, z: 120}
+  GachaLocation: {x: -0.2, y: 0.1, z: 0}
   mesh: {fileID: 433448404705881631}

--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_PartyHat.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_PartyHat.prefab
@@ -237,4 +237,5 @@ MonoBehaviour:
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
   GachaScale: {x: 120, y: 120, z: 120}
+  GachaLocation: {x: 0, y: -0.2, z: 0}
   mesh: {fileID: 3960243607965090699}

--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Pigtails.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Pigtails.prefab
@@ -185,4 +185,5 @@ MonoBehaviour:
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
   GachaScale: {x: 0.65, y: 0.65, z: 0.65}
+  GachaLocation: {x: 0, y: 0.3, z: 0}
   mesh: {fileID: 1885746496728884726}

--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Plunger.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Plunger.prefab
@@ -47,7 +47,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
-  GachaScale: {x: 0.9, y: 0.9, z: 0.9}
+  GachaScale: {x: 1, y: 1, z: 1}
+  GachaLocation: {x: 0, y: -0.4, z: 0}
   mesh: {fileID: 4049186947057140816}
 --- !u!1 &4049186947057140816
 GameObject:

--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_RainbowCap.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_RainbowCap.prefab
@@ -237,4 +237,5 @@ MonoBehaviour:
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
   GachaScale: {x: 120, y: 120, z: 120}
+  GachaLocation: {x: 0, y: -0.15, z: 0}
   mesh: {fileID: 1575802740823317741}

--- a/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Toilet.prefab
+++ b/Assets/Basils Models/Prefabs/Cosmetics/Cosmetic_Toilet.prefab
@@ -47,7 +47,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _defaultScale: {x: 0, y: 0, z: 0}
   _defaultPosition: {x: 0, y: 0, z: 0}
-  GachaScale: {x: 0.55, y: 0.55, z: 0.55}
+  GachaScale: {x: 0.9, y: 0.9, z: 0.9}
+  GachaLocation: {x: -0.1, y: -0.5, z: 0}
   mesh: {fileID: 4568711859852145573}
 --- !u!1 &4568711859852145573
 GameObject:

--- a/Assets/Cosmetic.cs
+++ b/Assets/Cosmetic.cs
@@ -7,6 +7,7 @@ public class Cosmetic : MonoBehaviour
     public Vector3 _defaultScale;
     public Vector3 _defaultPosition;
     public Vector3 GachaScale;
+    public Vector3 GachaLocation;
     public GameObject mesh;
     
     void Awake()
@@ -36,7 +37,7 @@ public class Cosmetic : MonoBehaviour
             if(GetComponentInChildren<Animator>() != null)
                 GetComponentInChildren<Animator>().enabled = false;
             mesh.transform.localScale = GachaScale;
-            mesh.transform.localPosition = Vector3.zero;
+            mesh.transform.localPosition = GachaLocation;
         }
     }
 }


### PR DESCRIPTION
Added a line to Cosmetic.cs that allows for per-clawsmetic positioning within their unequipped gacha form.
Clawsmetics with altered Gacha positions include:
- Cowboy hat
- Flower
- Party hat
- Cow bell
- Pig tails
- Moustache
- Googly eyes
- Toilet
- Plunger
- Prop hat